### PR TITLE
Moved api_key from url to header in request.

### DIFF
--- a/modules/recon/contacts-profiles/fullcontact.py
+++ b/modules/recon/contacts-profiles/fullcontact.py
@@ -15,8 +15,9 @@ class Module(BaseModule):
         base_url = 'https://api.fullcontact.com/v2/person.json'
         while emails:
             email = emails.pop(0)
-            payload = {'email':email, 'apiKey':api_key}
-            resp = self.request(base_url, payload=payload)
+            payload = {'email':email}
+            headers = {"X-FullContact-APIKey": api_key}
+            resp = self.request(base_url, payload=payload, headers=headers)
             if resp.status_code == 200:
                 # parse contact information
                 if 'contactInfo' in resp.json:


### PR DESCRIPTION
The current FullContact API appears to require the API key in the header 'X-FullContact-APIKey' rather than as a URL parameter.